### PR TITLE
added font-display swap to font-face declarations

### DIFF
--- a/dist/typography.css
+++ b/dist/typography.css
@@ -92,6 +92,7 @@
 @font-face {
   font-family: Avenir-Next;
   font-weight: 400;
+  font-display: swap;
   src: url(https://assets.digital.coop.co.uk/finder/static/fonts/e9167238-3b3f-4813-a04a-a384394eed42.eot#iefix);
   src: url(https://assets.digital.coop.co.uk/finder/static/fonts/e9167238-3b3f-4813-a04a-a384394eed42.eot#iefix)
       format("eot"),
@@ -106,6 +107,7 @@
   font-family: Avenir-Next;
   font-weight: 400;
   font-style: italic;
+  font-display: swap;
   src: url(https://assets.digital.coop.co.uk/finder/static/fonts/d1fddef1-d940-4904-8f6c-17e809462301.eot#iefix);
   src: url(https://assets.digital.coop.co.uk/finder/static/fonts/d1fddef1-d940-4904-8f6c-17e809462301.eot#iefix)
       format("eot"),
@@ -119,6 +121,7 @@
 @font-face {
   font-family: Avenir-Next;
   font-weight: 500;
+  font-display: swap;
   src: url(https://assets.digital.coop.co.uk/finder/static/fonts/1a7c9181-cd24-4943-a9d9-d033189524e0.eot#iefix);
   src: url(https://assets.digital.coop.co.uk/finder/static/fonts/1a7c9181-cd24-4943-a9d9-d033189524e0.eot#iefix)
       format("eot"),
@@ -132,6 +135,7 @@
 @font-face {
   font-family: Avenir-Next;
   font-weight: 600;
+  font-display: swap;
   src: url(https://assets.digital.coop.co.uk/finder/static/fonts/12d643f2-3899-49d5-a85b-ff430f5fad15.eot#iefix);
   src: url(https://assets.digital.coop.co.uk/finder/static/fonts/12d643f2-3899-49d5-a85b-ff430f5fad15.eot#iefix)
       format("eot"),
@@ -146,6 +150,7 @@
   font-family: Avenir-Next;
   font-weight: 600;
   font-style: italic;
+  font-display: swap;
   src: url(https://assets.digital.coop.co.uk/finder/static/fonts/770d9a7e-8842-4376-9319-8f2c8b8e880d.eot#iefix);
   src: url(https://assets.digital.coop.co.uk/finder/static/fonts/770d9a7e-8842-4376-9319-8f2c8b8e880d.eot#iefix)
       format("eot"),

--- a/src/_fonts.css
+++ b/src/_fonts.css
@@ -5,6 +5,7 @@
 @font-face {
   font-family: "Avenir-Next";
   font-weight: normal;
+  font-display: swap;
   src: url("https://assets.digital.coop.co.uk/finder/static/fonts/e9167238-3b3f-4813-a04a-a384394eed42.eot?#iefix");
   src: url("https://assets.digital.coop.co.uk/finder/static/fonts/e9167238-3b3f-4813-a04a-a384394eed42.eot?#iefix") format("eot"),
      url("https://assets.digital.coop.co.uk/finder/static/fonts/2cd55546-ec00-4af9-aeca-4a3cd186da53.woff2") format("woff2"),
@@ -16,6 +17,7 @@
   font-family: "Avenir-Next";
   font-weight: normal;
   font-style: italic;
+  font-display: swap;
   src: url("https://assets.digital.coop.co.uk/finder/static/fonts/d1fddef1-d940-4904-8f6c-17e809462301.eot?#iefix");
   src: url("https://assets.digital.coop.co.uk/finder/static/fonts/d1fddef1-d940-4904-8f6c-17e809462301.eot?#iefix") format("eot"),
        url("https://assets.digital.coop.co.uk/finder/static/fonts/7377dbe6-f11a-4a05-b33c-bc8ce1f60f84.woff2") format("woff2"),
@@ -26,6 +28,7 @@
 @font-face{
   font-family:"Avenir-Next";
   font-weight: 500;
+  font-display: swap;
   src: url("https://assets.digital.coop.co.uk/finder/static/fonts/1a7c9181-cd24-4943-a9d9-d033189524e0.eot?#iefix");
   src: url("https://assets.digital.coop.co.uk/finder/static/fonts/1a7c9181-cd24-4943-a9d9-d033189524e0.eot?#iefix") format("eot"),
     url("https://assets.digital.coop.co.uk/finder/static/fonts/627fbb5a-3bae-4cd9-b617-2f923e29d55e.woff2") format("woff2"),
@@ -36,6 +39,7 @@
 @font-face {
   font-family: "Avenir-Next";
   font-weight: 600;
+  font-display: swap;
   src: url("https://assets.digital.coop.co.uk/finder/static/fonts/12d643f2-3899-49d5-a85b-ff430f5fad15.eot?#iefix");
   src: url("https://assets.digital.coop.co.uk/finder/static/fonts/12d643f2-3899-49d5-a85b-ff430f5fad15.eot?#iefix") format("eot"),
        url("https://assets.digital.coop.co.uk/finder/static/fonts/aad99a1f-7917-4dd6-bbb5-b07cedbff64f.woff2") format("woff2"),
@@ -47,6 +51,7 @@
   font-family: "Avenir-Next";
   font-weight: 600;
   font-style: italic;
+  font-display: swap;
   src: url("https://assets.digital.coop.co.uk/finder/static/fonts/770d9a7e-8842-4376-9319-8f2c8b8e880d.eot?#iefix");
   src: url("https://assets.digital.coop.co.uk/finder/static/fonts/770d9a7e-8842-4376-9319-8f2c8b8e880d.eot?#iefix") format("eot"),
        url("https://assets.digital.coop.co.uk/finder/static/fonts/687932cb-145b-4690-a21d-ed1243db9e36.woff2") format("woff2"),


### PR DESCRIPTION
Added font-display property to avoid flash of invisible text [in supported browsers](https://caniuse.com/#search=font-display)

This means the browser draws text immediately with a fallback if the font face isn’t loaded, but swaps the font face in as soon as it loads.